### PR TITLE
Upgraded examples to match latest API

### DIFF
--- a/src/friend_oauth2_examples/appdotnet_handler.clj
+++ b/src/friend_oauth2_examples/appdotnet_handler.clj
@@ -9,7 +9,10 @@
             (cemerick.friend [workflows :as workflows]
                              [credentials :as creds])))
 
-(def config-auth {:roles #{::user}})
+(defn credential-fn
+  [token]
+  ;;lookup token in DB or whatever to fetch appropriate :roles
+  {:identity token :roles #{::user}})
 
 (def client-config
   {:client-id ""
@@ -54,4 +57,4 @@
      :workflows [(oauth2/workflow
                   {:client-config client-config
                    :uri-config uri-config
-                   :config-auth config-auth})]})))
+                   :credential-fn credential-fn})]})))

--- a/src/friend_oauth2_examples/facebook_handler.clj
+++ b/src/friend_oauth2_examples/facebook_handler.clj
@@ -8,7 +8,10 @@
             (cemerick.friend [workflows :as workflows]
                              [credentials :as creds])))
 
-(def config-auth {:roles #{::user}})
+(defn credential-fn
+  [token]
+  ;;lookup token in DB or whatever to fetch appropriate :roles
+  {:identity token :roles #{::user}})
 
 (def client-config
   {:client-id ""
@@ -51,4 +54,4 @@
                   {:client-config client-config
                    :uri-config uri-config
                    :access-token-parsefn get-access-token-from-params
-                   :config-auth config-auth})]})))
+                   :credential-fn credential-fn})]})))

--- a/src/friend_oauth2_examples/github_handler.clj
+++ b/src/friend_oauth2_examples/github_handler.clj
@@ -14,7 +14,10 @@
 (declare render-repos-page)
 (declare get-github-repos)
 
-(def config-auth {:roles #{::user}})
+(defn credential-fn
+  [token]
+  ;;lookup token in DB or whatever to fetch appropriate :roles
+  {:identity token :roles #{::user}})
 
 (def client-config
   {:client-id ""
@@ -51,7 +54,7 @@
                   {:client-config client-config
                    :uri-config uri-config
                    :access-token-parsefn get-access-token-from-params
-                   :config-auth config-auth})]})))
+                   :credential-fn credential-fn})]})))
 
 (defn render-status-page [request]
   (let [count (:count (:session request) 0)

--- a/src/friend_oauth2_examples/google_handler.clj
+++ b/src/friend_oauth2_examples/google_handler.clj
@@ -9,7 +9,10 @@
             (cemerick.friend [workflows :as workflows]
                              [credentials :as creds])))
 
-(def config-auth {:roles #{::user}})
+(defn credential-fn
+  [token]
+  ;;lookup token in DB or whatever to fetch appropriate :roles
+  {:identity token :roles #{::user}})
 
 (def client-config
   {:client-id ""
@@ -54,4 +57,4 @@
      :workflows [(oauth2/workflow
                   {:client-config client-config
                    :uri-config uri-config
-                   :config-auth config-auth})]})))
+                   :credential-fn credential-fn})]})))


### PR DESCRIPTION
Moved from `:config-auth` to `:credential-fn`. Fixes #4 and #7.